### PR TITLE
refactor: Rename ThredManager to ThreadManager

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -11,7 +11,7 @@ import tomli
 import pyfiglet
 from colorama import Fore, Style
 
-from lib.packages_main.manager import ThredManager
+from lib.packages_main.manager import ThreadManager
 import lib.packages_utility.logger  # noqa: F401
 import logging
 from lib.packages_utility.utils import init_settings
@@ -161,7 +161,7 @@ def main():  # noqa: PLR0915
         request_maker.download_model_en()
         logging.info(" Download finish")
 
-    manager = ThredManager(settings,default_start)
+    manager = ThreadManager(settings,default_start)
     manager.init()
     manager.start()
 

--- a/lib/packages_main/manager.py
+++ b/lib/packages_main/manager.py
@@ -33,7 +33,7 @@ def choise_input():
         else:
             logging.warning(" Select a valid choice please")
 
-class ThredManager:
+class ThreadManager:
     """This class manages all threads and processes that are running in the background."""
     def __init__(self,settings,default_start:str):
         """Init function.


### PR DESCRIPTION
This commit renames the `ThredManager` class to `ThreadManager` in the
`launch.py` and `manager.py` files.

The new name better reflects the purpose of the class, which is to
manage all threads and processes running in the background. This change
improves code clarity and readability.

No issue references.